### PR TITLE
Bug: Fix concurrent child processes breaking download

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -168,6 +168,28 @@ function extract(logger, compressionLib, file) {
 
     return outputLocation;
 
+  }).catch(function (error) {
+
+    if (typeof error === 'string') {
+
+      // some libraries may not reject
+      // with an error so convert into one
+
+      throw new Error(error);
+
+    } else if (error instanceof Error) {
+
+      // rethrow previous error
+
+      throw error;
+
+    }
+
+    // something else in the rejection
+    // just return a generic error
+
+    throw new Error('Unable to extract from ' + file);
+
   });
 
 }

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -3,7 +3,6 @@ var packageVersion = require('../version');
 var Promise = require('yaku');
 var fs = require('fs-extra');
 var path = require('path');
-var os = require('os');
 var url = require('url');
 
 function getPackageVersion() {
@@ -89,7 +88,7 @@ function getDownloadUrl(cdnUrl, filename) {
 
 function createTmpDir(logger) {
 
-  var sauceTmpDir = path.join(os.tmpdir(), 'sauceconnect');
+  var sauceTmpDir = path.join(__dirname, 'sauceconnect');
 
   return new Promise(function (resolve, reject) {
 
@@ -156,7 +155,7 @@ function extract(logger, compressionLib, file) {
     });
 
     if (scFiles.length !== 1) {
-      return Promise.reject('Could not find sauce connect executable in zip file');
+      return Promise.reject(new Error('Could not find sauce connect executable in zip file'));
     }
 
     // only file should be binary
@@ -169,8 +168,6 @@ function extract(logger, compressionLib, file) {
 
     return outputLocation;
 
-  }).catch(function (error) {
-    return new Error(error);
   });
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sauce-connect",
-  "version": "4.4.5-beta-2",
+  "version": "4.4.5-beta-3",
   "keywords": [
     "saucelabs",
     "sauce-connect",

--- a/tests/lib.test.js
+++ b/tests/lib.test.js
@@ -4,7 +4,6 @@ var fs = require('fs-extra');
 var stream = require('stream');
 var chai = require('chai');
 var expect = chai.expect;
-var os = require('os');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
 var Promise = require('yaku');
@@ -170,7 +169,7 @@ describe('lib.js', function () {
 
 
   describe('createTmpDir', function () {
-    var tmpDir = path.join(os.tmpdir(), 'sauceconnect');
+    var tmpDir = path.resolve(path.join(__dirname, '../lib/sauceconnect'));
     var loggerStub;
     var ensureDirStub;
 
@@ -335,7 +334,7 @@ describe('lib.js', function () {
 
     it('should reject if it cannot decompress the archive', function () {
 
-      decompressStub.returns(Promise.reject('Error'));
+      decompressStub.returns(Promise.reject(new Error('Error')));
 
       return lib.extract(loggerStub, decompressStub, fakeZipPath).then(function () {
         throw new Error('was not supposed to resolve');

--- a/tests/lib.test.js
+++ b/tests/lib.test.js
@@ -324,6 +324,7 @@ describe('lib.js', function () {
   });
 
   describe('extract', function () {
+    var errorMessage = 'Test error message';
     var decompressStub;
     var loggerStub;
 
@@ -334,12 +335,39 @@ describe('lib.js', function () {
 
     it('should reject if it cannot decompress the archive', function () {
 
-      decompressStub.returns(Promise.reject(new Error('Error')));
+      decompressStub.returns(Promise.reject(new Error(errorMessage)));
 
       return lib.extract(loggerStub, decompressStub, fakeZipPath).then(function () {
         throw new Error('was not supposed to resolve');
       }).catch(function (error) {
         expect(error).to.be.a('Error');
+
+      });
+
+    });
+
+    it('should convert a string to an error if rejected', function () {
+
+      decompressStub.returns(Promise.reject(errorMessage));
+
+      return lib.extract(loggerStub, decompressStub, fakeZipPath).then(function () {
+        throw new Error('was not supposed to resolve');
+      }).catch(function (error) {
+        expect(error).to.be.a('Error');
+        expect(error.message).to.equal(errorMessage);
+      });
+
+    });
+
+    it('should return a generic error message if is not a string or error', function () {
+
+      decompressStub.returns(Promise.reject());
+
+      return lib.extract(loggerStub, decompressStub, fakeZipPath).then(function () {
+        throw new Error('was not supposed to resolve');
+      }).catch(function (error) {
+        expect(error).to.be.a('Error');
+        expect(error.message).to.equal('Unable to extract from ' + fakeZipPath);
       });
 
     });


### PR DESCRIPTION
Bug: When multiple Jenkins jobs are being run at the same time on the same host, there are collisions with the child processes downloading to os.tmp()/sauceconnect. Now use the module directory as the temporary location as it will exist in a separate workspace and guarantee we won't collide with other processes.